### PR TITLE
travis: PHP 5.6 and 7.0 nightly added + other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: php
+
 php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
   - hhvm
-
-before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
-
-branches:
-  only:
-    - master
 
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7.0
   fast_finish: true
+
+before_script:
+  - composer self-update
+  - composer install --prefer-source --no-interaction
+
+script:
+  - phpunit


### PR DESCRIPTION
- `--dev` is by default for almost a year
- don't hide `phpunit`, make it explicit