### PR TITLE
Adding RulerZ as a sample for Specification pattern

### DIFF
--- a/Behavioral/Specification/README.rst
+++ b/Behavioral/Specification/README.rst
@@ -9,6 +9,11 @@ checked against. The composite specification class has one method called
 ``isSatisfiedBy`` that returns either true or false depending on whether
 the given object satisfies the specification.
 
+Sample:
+^^^^^^^
+
+-  `RulerZ <https://github.com/K-Phoen/rulerz>`__ 
+
 UML Diagram
 -----------
 


### PR DESCRIPTION
RulerZ is a PHP implementation of the Specification pattern which puts the emphasis on three main aspects:

  - an easy and data-agnostic DSL to define business rules and specifications,
  - the ability to check if a candidate satisfies a specification,
  - the ability to filter or query any datasource to only retrieve candidates matching a specification.