### PR TITLE
add visibility declaration to __construct

### DIFF
--- a/Behavioral/Observer/User.php
+++ b/Behavioral/Observer/User.php
@@ -24,7 +24,7 @@ class User implements \SplSubject
      */
     protected $observers;
     
-    function __construct()
+    public function __construct()
     {
         $this->observers = new \SplObjectStorage();
     }


### PR DESCRIPTION
Just cloned the repo and run CodeSniffer, found there was a __construct method without the visibility declaration. 