### PR TITLE
Fix: Execute build steps on Travis in appropriate sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 before_install:
   - composer self-update
   
-before_script:
+install:
   - composer install --prefer-dist --no-interaction
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
+before_install:
   - composer self-update
+  
+before_script:
   - composer install --prefer-dist --no-interaction
 
 script:


### PR DESCRIPTION
This PR

* [x] runs `composer self-update` in `before_install` section
* [x] runs `composer install` in `install` section