### PR TITLE
Fix: Use phpunit as installed with Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
   - composer install --prefer-source --no-interaction
 
 script:
-  - phpunit
+  - vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] uses the same `phpunit` on Travis as installed with Composer