### PR TITLE
Enhancement: Use SVG badge for displaying Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DesignPatternsPHP
 
-[![Build Status](https://travis-ci.org/domnikl/DesignPatternsPHP.png?branch=master)](https://travis-ci.org/domnikl/DesignPatternsPHP)
+[![Build Status](https://travis-ci.org/domnikl/DesignPatternsPHP.svg?branch=master)](https://travis-ci.org/domnikl/DesignPatternsPHP)
 
 [Read the Docs of DesignPatternsPHP](http://designpatternsphp.readthedocs.org)
 or [Download as PDF/Epub](https://readthedocs.org/projects/designpatternsphp/downloads/)


### PR DESCRIPTION
This PR

* [x] uses an SVG badge for displaying the Travis build status, as it pleases the eye