### PR TITLE
Fixed wrong implementation of Singleton Pattern

### DIFF
--- a/Creational/Singleton/Singleton.php
+++ b/Creational/Singleton/Singleton.php
@@ -2,6 +2,8 @@
 
 namespace DesignPatterns\Creational\Singleton;
 
+use DesignPatterns\Creational\Singleton\SingletonPatternViolationException;
+
 /**
  * class Singleton
  */
@@ -36,19 +38,21 @@ class Singleton
 
     /**
      * prevent the instance from being cloned
-     *
+     * @throws SingletonPatternViolationException
      * @return void
      */
-    private function __clone()
+    public final function __clone()
     {
+        throw new SingletonPatternViolationException('This is a Singleton. Clone is forbidden');
     }
 
     /**
      * prevent from being unserialized
-     *
+     * @throws SingletonPatternViolationException
      * @return void
      */
-    private function __wakeup()
+    public final function __wakeup()
     {
+        throw new SingletonPatternViolationException('This is a Singleton. __wakeup usage is forbidden');
     }
 }

--- a/Creational/Singleton/SingletonPatternViolationException.php
+++ b/Creational/Singleton/SingletonPatternViolationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DesignPatterns\Creational\Singleton;
+
+class SingletonPatternViolationException extends \Exception
+{
+
+}

--- a/Creational/Singleton/Tests/SingletonTest.php
+++ b/Creational/Singleton/Tests/SingletonTest.php
@@ -26,4 +26,25 @@ class SingletonTest extends \PHPUnit_Framework_TestCase
         $meth = $refl->getMethod('__construct');
         $this->assertTrue($meth->isPrivate());
     }
+
+    /**
+     * @expectedException \DesignPatterns\Creational\Singleton\SingletonPatternViolationException
+     * @return void
+     */
+    public function testNoCloneAllowed()
+    {
+        $obj1 = Singleton::getInstance();
+        $obj2 = clone $obj1;
+    }
+
+    /**
+     * @expectedException \DesignPatterns\Creational\Singleton\SingletonPatternViolationException
+     * @return void
+     */
+    public function testNoSerializationAllowed()
+    {
+        $obj1 = Singleton::getInstance();
+        $serialized = serialize($obj1);
+        $obj2 = unserialize($serialized);
+    }
 }


### PR DESCRIPTION
Singleton pattern was functional only for new instances using `Singleton::getInstance()`.
This PR is fixing the cloning:
```php
$obj1 = Singleton::getInstance();
$obj2 = clone $obj1;
```
and serialize/unserialization the singleton object.
```php
$obj1 = Singleton::getInstance();
$serialized = serialize($obj1);
$obj2 = unserialize($serialized);
```

> Having protected/private `__wakeup()` method will output a warning but script will continue and will provide a new instance of the first object. Throwing an exception on `__clone` and `__wakeup` is much safer. Making them `final` will prevent overwriting if class is extended.