### PR TITLE
Removed returns on `addBook` and `removeBook`

### DIFF
--- a/Behavioral/Iterator/BookList.php
+++ b/Behavioral/Iterator/BookList.php
@@ -19,8 +19,6 @@ class BookList implements \Countable
     public function addBook(Book $book)
     {
         $this->books[] = $book;
-
-        return $this->count();
     }
 
     public function removeBook(Book $bookToRemove)
@@ -31,8 +29,6 @@ class BookList implements \Countable
                 unset($this->books[$key]);
             }
         }
-
-        return $this->count();
     }
 
     public function count()


### PR DESCRIPTION
I removed the returning of `count()` from the `BookList` because it does not make sense to do so when adding and removing books. If the user of that particular code wanted to get the count, they can simply invoke the `count()` method. What those returns did was a waste of processing.