### PR TITLE
181 - Updated doc for Vehicle class in Builder pattern

### DIFF
--- a/Creational/Builder/Parts/Vehicle.php
+++ b/Creational/Builder/Parts/Vehicle.php
@@ -3,7 +3,7 @@
 namespace DesignPatterns\Creational\Builder\Parts;
 
 /**
- * VehicleInterface is a contract for a vehicle.
+ * Vehicle class is an abstraction for a vehicle.
  */
 abstract class Vehicle
 {


### PR DESCRIPTION
Fix for #181 

Because VehicleInterface was removed it is a good idea to fix doc block for Vehicle class