### PR TITLE
89 - ConcreteFactory changed to SimpleFactory

### DIFF
--- a/Creational/SimpleFactory/README.rst
+++ b/Creational/SimpleFactory/README.rst
@@ -4,7 +4,7 @@ Simple Factory
 Purpose
 -------
 
-ConcreteFactory is a simple factory pattern.
+SimpleFactory is a simple factory pattern.
 
 It differs from the static factory because it is NOT static and as you
 know: static => global => evil!
@@ -24,9 +24,9 @@ Code
 
 You can also find these code on `GitHub`_
 
-ConcreteFactory.php
+SimpleFactory.php
 
-.. literalinclude:: ConcreteFactory.php
+.. literalinclude:: SimpleFactory.php
    :language: php
    :linenos:
 
@@ -53,7 +53,7 @@ Usage
 
 .. code::  php
 
-   $factory = new ConcreteFactory();
+   $factory = new SimpleFactory();
    $bicycle = $factory->createVehicle('bicycle');
    $bicycle->driveTo('Paris');
 

--- a/Creational/SimpleFactory/SimpleFactory.php
+++ b/Creational/SimpleFactory/SimpleFactory.php
@@ -3,9 +3,9 @@
 namespace DesignPatterns\Creational\SimpleFactory;
 
 /**
- * class ConcreteFactory.
+ * class SimpleFactory.
  */
-class ConcreteFactory
+class SimpleFactory
 {
     /**
      * @var array

--- a/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
+++ b/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace DesignPatterns\Creational\SimpleFactory\Tests;
 
-use DesignPatterns\Creational\SimpleFactory\ConcreteFactory;
+use DesignPatterns\Creational\SimpleFactory\SimpleFactory;
 
 /**
  * SimpleFactoryTest tests the Simple Factory pattern.
@@ -13,7 +13,7 @@ class SimpleFactoryTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->factory = new ConcreteFactory();
+        $this->factory = new SimpleFactory();
     }
 
     public function getType()

--- a/Creational/SimpleFactory/uml/SimpleFactory.uml
+++ b/Creational/SimpleFactory/uml/SimpleFactory.uml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Diagram>
   <ID>PHP</ID>
-  <OriginalElement>\DesignPatterns\Creational\SimpleFactory\ConcreteFactory</OriginalElement>
+  <OriginalElement>\DesignPatterns\Creational\SimpleFactory\SimpleFactory</OriginalElement>
   <nodes>
     <node x="173.0" y="97.0">\DesignPatterns\Creational\SimpleFactory\Scooter</node>
-    <node x="0.0" y="189.0">\DesignPatterns\Creational\SimpleFactory\ConcreteFactory</node>
+    <node x="0.0" y="189.0">\DesignPatterns\Creational\SimpleFactory\SimpleFactory</node>
     <node x="86.5" y="0.0">\DesignPatterns\Creational\SimpleFactory\VehicleInterface</node>
     <node x="0.0" y="97.0">\DesignPatterns\Creational\SimpleFactory\Bicycle</node>
   </nodes>

--- a/Creational/SimpleFactory/uml/uml.svg
+++ b/Creational/SimpleFactory/uml/uml.svg
@@ -201,10 +201,10 @@
       <image x="2" y="1" clip-path="url(#clipPath27)" width="16" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACKklEQVR42mNgoBAw&#13;&#10;ogssuvhB8cvPX5M+//hj8f8/oyBYEeP/dzycrEd52ViL4vQF7uM0YO7ZV1WvPv+p&#13;&#10;lxTkZBPkZmNgZoJI//33n+H9118Mz99//yXGy9KYbCzWBtPDDGPMBmp+8/Vvq4YU&#13;&#10;PzM3OwvQVkaG/0Dx/2AXMDJwsrEwCPOyMz9698M5PKf89+ZZ3YdB+phAxILLL5Vf&#13;&#10;fP5dryrJx8AItPUfUAwbBsmB1IDULr7ySgWklwVEfPrK0CPGx8kG8tFfoMqf378y&#13;&#10;7FsyjeHWqYNw7+XP3gL3NUjt28+/+oEcX7ABH77/sVYX4Gb49/8/WMmu+RMYpFS1&#13;&#10;GdxTSuAGwORAQICLjeHFh+8WcC/8/vNf6D/Qn3+BakD40bXzDDoO3nA+Ogap/f33&#13;&#10;vxDcCzAJGPj98wdE4X+8KeAv3AVMzIzvgCbCDZLRMmS4cXwfThf8htj2Ee4CHg7m&#13;&#10;o2+//AgQ4uUAm20bV8hwePFEhsNLJsPtS5y2Cc5+9+UHAzcX0wm4AbwcTKUPX333&#13;&#10;4uVkZwMlHnYeAQaXzHoUB//7xwBPVC/fff8lL8ZeCE9I22Z1vwvMKf/3+O0PZz5u&#13;&#10;dlDKgSciZPwHqPnei08MYvwsdQVm4htRUuKuuT2H/TPL/j5+/dUGmGCY2ViYwAn9&#13;&#10;Pzwp/2R48vrzLwkB1roSS4k2nJlp8skXiu+//5306fs/yz///wsyMTL+ZWZkeM/L&#13;&#10;yXxckIOpMNdc4j4DNQEAbyj/ikXNHnwAAAAASUVORK5CYII=" height="16" preserveAspectRatio="none"/>
     </g>
     <g font-size="11" transform="matrix(1,0,0,1,28,20) translate(4,193)" fill-opacity="0.1961" fill="rgb(0,0,0)" font-family="'Tahoma'" stroke="rgb(0,0,0)" stroke-opacity="0.1961">
-      <text x="21" xml:space="preserve" y="14" clip-path="url(#clipPath27)" stroke="none">ConcreteFactory</text>
+      <text x="21" xml:space="preserve" y="14" clip-path="url(#clipPath27)" stroke="none">SimpleFactory</text>
     </g>
     <g fill="rgb(187,187,187)" font-size="11" font-family="'Tahoma'" transform="matrix(1,0,0,1,28,20) translate(4,193)" stroke="rgb(187,187,187)">
-      <text x="21" xml:space="preserve" y="13" clip-path="url(#clipPath27)" stroke="none">ConcreteFactory</text>
+      <text x="21" xml:space="preserve" y="13" clip-path="url(#clipPath27)" stroke="none">SimpleFactory</text>
     </g>
     <g fill="rgb(120,120,120)" font-size="11" font-family="'Tahoma'" transform="matrix(1,0,0,1,28,20) translate(78.5,0)" stroke="rgb(120,120,120)">
       <path d="M0 0 L169 0 L169 47 L0 47 L0 0 ZM1 1 L168 1 L168 46 L1 46 L1 1 Z" clip-path="url(#clipPath4)" fill-rule="evenodd" stroke="none"/>

--- a/locale/ca/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/ca/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -20,7 +20,7 @@ msgid "Purpose"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:7
-msgid "ConcreteFactory is a simple factory pattern."
+msgid "SimpleFactory is a simple factory pattern."
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:9
@@ -48,7 +48,7 @@ msgid "You can also find these code on `GitHub`_"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:27
-msgid "ConcreteFactory.php"
+msgid "SimpleFactory.php"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:33

--- a/locale/es/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/es/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -20,7 +20,7 @@ msgid "Purpose"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:7
-msgid "ConcreteFactory is a simple factory pattern."
+msgid "SimpleFactory is a simple factory pattern."
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:9
@@ -48,7 +48,7 @@ msgid "You can also find these code on `GitHub`_"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:27
-msgid "ConcreteFactory.php"
+msgid "SimpleFactory.php"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:33

--- a/locale/pt_BR/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/pt_BR/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -20,7 +20,7 @@ msgid "Purpose"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:7
-msgid "ConcreteFactory is a simple factory pattern."
+msgid "SimpleFactory is a simple factory pattern."
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:9
@@ -48,7 +48,7 @@ msgid "You can also find these code on `GitHub`_"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:27
-msgid "ConcreteFactory.php"
+msgid "SimpleFactory.php"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:33

--- a/locale/ru/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/ru/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -20,8 +20,8 @@ msgid "Purpose"
 msgstr "Назначение"
 
 #: ../../Creational/SimpleFactory/README.rst:7
-msgid "ConcreteFactory is a simple factory pattern."
-msgstr "ConcreteFactory в примере ниже, это паттерн «Простая Фабрика»."
+msgid "SimpleFactory is a simple factory pattern."
+msgstr "SimpleFactory в примере ниже, это паттерн «Простая Фабрика»."
 
 #: ../../Creational/SimpleFactory/README.rst:9
 msgid ""
@@ -53,8 +53,8 @@ msgid "You can also find these code on `GitHub`_"
 msgstr "Вы можете найти этот код на `GitHub`_"
 
 #: ../../Creational/SimpleFactory/README.rst:27
-msgid "ConcreteFactory.php"
-msgstr "ConcreteFactory.php"
+msgid "SimpleFactory.php"
+msgstr "SimpleFactory.php"
 
 #: ../../Creational/SimpleFactory/README.rst:33
 msgid "VehicleInterface.php"

--- a/locale/zh_CN/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/zh_CN/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -20,7 +20,7 @@ msgid "Purpose"
 msgstr "目的"
 
 #: ../../Creational/SimpleFactory/README.rst:7
-msgid "ConcreteFactory is a simple factory pattern."
+msgid "SimpleFactory is a simple factory pattern."
 msgstr "简单的创建对象型工厂模式"
 
 #: ../../Creational/SimpleFactory/README.rst:9
@@ -52,7 +52,7 @@ msgid "You can also find these code on `GitHub`_"
 msgstr "你可以在 `GitHub`_ 上找到这些代码"
 
 #: ../../Creational/SimpleFactory/README.rst:27
-msgid "ConcreteFactory.php"
+msgid "SimpleFactory.php"
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:33


### PR DESCRIPTION
Fix for #89 

Actually it is good idea to use 1 standardized name.
As referenced in #89 and book "Head First DP book" it is better to call it SimpleFactory.