### PR TITLE
Extend UndoableCommandInterface from CommandInterface

### DIFF
--- a/Behavioral/Command/AddMessageDateCommand.php
+++ b/Behavioral/Command/AddMessageDateCommand.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\Command;
  * This concrete command tweaks receiver to add current date to messages
  * invoker just knows that it can call "execute".
  */
-class AddMessageDateCommand implements CommandInterface, UndoableCommandInterface
+class AddMessageDateCommand implements UndoableCommandInterface
 {
     /**
      * @var Receiver

--- a/Behavioral/Command/UndoableCommandInterface.php
+++ b/Behavioral/Command/UndoableCommandInterface.php
@@ -5,7 +5,7 @@ namespace DesignPatterns\Behavioral\Command;
 /**
  * Interface UndoableCommandInterface.
  */
-interface UndoableCommandInterface
+interface UndoableCommandInterface extends CommandInterface
 {
     /**
      * This method is used to undo change made by command execution


### PR DESCRIPTION
Hey guys,

I propose to extend ```UndoableCommandInterface``` from ```CommandInterface``` for the following reasons:
1. It contains only ```undo``` method which doesn't look like command at all
2. We can't correctly work this interface. Please look at these examples with simplified invokers:
```php
function executeCommand(CommandInterface $command)
{
    $command->execute();
    $command->undo(); // undo is not part of the CommandInterface
}

function executeUndoableCommand(UndoableCommandInterface $command)
{
    $command->execute(); // execute is not part of UndoableCommandInterface
    $command->undo();
}
```
In both cases we can't follow the declared interface to work with the command.

Thanks,
Ihor