### PR TITLE
State container Pattern

### DIFF
--- a/Structural/DependencyInjection/Tests/StateContainerTest.php
+++ b/Structural/DependencyInjection/Tests/StateContainerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DesignPatterns\Structural\StateContainer\Tests;
+
+use DesignPatterns\Structural\StateContainer\StateContainer;
+
+class StateContainerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function setup()
+    {
+        StateContainer::init(function ($state, $action) {
+
+            switch($action) {
+              
+                case 'INCREMENT':
+                    return $state = $state + 1;
+                    break;
+
+                case 'DECREMENT':
+                    return $state = $state - 1;
+                    break;
+
+                default:
+                    return 0;
+                    break;
+
+            }
+
+        });
+    }
+
+    /**
+     * Using StateContainer as central repository of truth from which 
+     * derive html presentation.
+     */
+    public function testStateModify()
+    {
+        StateContainer::dispatch('INCREMENT');
+        $this->assertEquals(1, StateContainer::getState());
+    }
+
+
+    /**
+     * Using StateContainer as a reliable and straight forward 
+     * approach to reproduce use cases.
+     */
+    public function testReplayActions()
+    {
+        $actions = ['INCREMENT', 'INCREMENT', 'DECREMENT', 'INCREMENT'];
+
+        foreach ($actions as $action) {
+            StateContainer::dispatch($action);
+        }
+
+        $this->assertEquals(2, StateContainer::getState());
+    }
+}

--- a/Structural/DependencyInjection/Tests/StateContainerTest.php
+++ b/Structural/DependencyInjection/Tests/StateContainerTest.php
@@ -11,7 +11,7 @@ class StateContainerTest extends \PHPUnit_Framework_TestCase
     {
         StateContainer::init(function ($state, $action) {
 
-            switch($action) {
+            switch ($action) {
               
                 case 'INCREMENT':
                     return $state = $state + 1;
@@ -31,7 +31,7 @@ class StateContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Using StateContainer as central repository of truth from which 
+     * Using StateContainer as central repository of truth from which
      * derive html presentation.
      */
     public function testStateModify()
@@ -42,12 +42,12 @@ class StateContainerTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * Using StateContainer as a reliable and straight forward 
+     * Using StateContainer as a reliable and straight forward
      * approach to reproduce use cases.
      */
     public function testReplayActions()
     {
-        $actions = ['INCREMENT', 'INCREMENT', 'DECREMENT', 'INCREMENT'];
+        $actions = array('INCREMENT', 'INCREMENT', 'DECREMENT', 'INCREMENT');
 
         foreach ($actions as $action) {
             StateContainer::dispatch($action);

--- a/Structural/StateContainer/README.rst
+++ b/Structural/StateContainer/README.rst
@@ -25,17 +25,15 @@ Code
 
 You can also find these code on `GitHub`_
 
-StateContainer.php
-
 .. literalinclude:: StateContainer.php
-   :language: php
-   :linenos:
-
-Controller.php
-
-.. literalinclude:: Controller.php
    :language: php
    :linenos:
 
 Test
 ----
+
+.. literalinclude:: Tests/StateContainerTest.php
+   :language: php
+   :linenos: 
+
+.. _`GitHub`: https://github.com/domnikl/DesignPatternsPHP/tree/master/Structural/StateContainer

--- a/Structural/StateContainer/README.rst
+++ b/Structural/StateContainer/README.rst
@@ -1,4 +1,4 @@
-`State Container`__
+State Container
 ===============
 
 Purpose
@@ -6,7 +6,7 @@ Purpose
 
 A State Container is a class which contains the state of the app as a central repository. Other  This allows to build your application like stateless functions/components that send messages to the central repository and are easy to test. It also allows to do some data operations easier, like caching, data exportation.
 
-This pattern have been popularized recently by the Redux JavaScript library and it is specially usefull for the presentation layer and to keep track of every user action in the application for analytics.   
+This pattern have been popularized recently by the Redux JavaScript library and it is specially usefull for the presentation layer and to keep track of every user action in the application for analytics. More info about the pattern used in other languages and stacks here: `Redux influences`_
 
 Examples
 --------
@@ -37,3 +37,4 @@ Test
    :linenos: 
 
 .. _`GitHub`: https://github.com/domnikl/DesignPatternsPHP/tree/master/Structural/StateContainer
+.. _`Redux influences`: https://github.com/reactjs/redux#thanks

--- a/Structural/StateContainer/README.rst
+++ b/Structural/StateContainer/README.rst
@@ -11,9 +11,9 @@ This pattern have been popularized recently by the Redux JavaScript library and 
 Examples
 --------
 
--  Wizard application with several steps: In client applications some objects can subscribe to the changes in the repository and update themselves according to them. In this example, as we are studing PHP implementations and server side code instead of subscribing to the changes we will simulate a two steps process, in the first step the server receive the action and modifies the state, in the second state the server returns the result acording to the new state.
+-  Wizard application with several steps: In client applications some objects can subscribe to the changes in the repository and update themselves according to them. In this example, as we are studing PHP implementations and server side code instead of subscribing to the changes we can simulate a two steps process, in the first step the server receive the action and modifies the state, in the second state the server returns the result acording to the new state.
 
-- User actions tracking: stores all user actions as an unique stream. This allows for reproduction of the user interaction for testing purposes and analitycs of user behaviours.
+- User actions tracking: stores all user actions as an unique stream. This allows for reproduction of the user interaction for testing purposes and also for analitycs of user behaviours, this stream-consumer.
 
 UML Diagram
 -----------

--- a/Structural/StateContainer/README.rst
+++ b/Structural/StateContainer/README.rst
@@ -1,0 +1,41 @@
+`State Container`__
+===============
+
+Purpose
+-------
+
+A State Container is a class which contains the state of the app as a central repository. Other  This allows to build your application like stateless functions/components that send messages to the central repository and are easy to test. It also allows to do some data operations easier, like caching, data exportation.
+
+This pattern have been popularized recently by the Redux JavaScript library and it is specially usefull for the presentation layer and to keep track of every user action in the application for analytics.   
+
+Examples
+--------
+
+-  Wizard application with several steps: In client applications some objects can subscribe to the changes in the repository and update themselves according to them. In this example, as we are studing PHP implementations and server side code instead of subscribing to the changes we will simulate a two steps process, in the first step the server receive the action and modifies the state, in the second state the server returns the result acording to the new state.
+
+- User actions tracking: stores all user actions as an unique stream. This allows for reproduction of the user interaction for testing purposes and analitycs of user behaviours.
+
+UML Diagram
+-----------
+
+TODO
+
+Code
+----
+
+You can also find these code on `GitHub`_
+
+StateContainer.php
+
+.. literalinclude:: StateContainer.php
+   :language: php
+   :linenos:
+
+Controller.php
+
+.. literalinclude:: Controller.php
+   :language: php
+   :linenos:
+
+Test
+----

--- a/Structural/StateContainer/StateContainer.php
+++ b/Structural/StateContainer/StateContainer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DesignPatterns\Structural\StateContainer;
+
+class StateContainer
+{
+    private static $state = null;
+    private static $reducer = null;
+
+    public static function init($reducer)
+    {
+        static::$reducer = $reducer;
+        static::$state = null;
+
+        static::$state = call_user_func_array(static::$reducer, array(null, null));
+    }
+
+    public static function dispatch($action)
+    {
+        if (static::$reducer == null) {
+            throw new StoreNotInitializedException();
+        }
+
+        static::$state = call_user_func_array(static::$reducer, array(static::$state, $action));
+    }
+
+    public static function getState()
+    {
+        return static::$state;
+    }
+}

--- a/Structural/StateContainer/StoreNotInitializedException.php
+++ b/Structural/StateContainer/StoreNotInitializedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DesignPatterns\Structural\StateContainer;
+
+class StoreNotInitializedException extends \Exception
+{
+}


### PR DESCRIPTION
Hi @domnikl, 

I want to propose a new pattern. I have been learning [Flux](http://facebook.github.io/flux/docs/overview.html) lately and I thought that It would be an interesting exercise to try and reproduce the Redux approach in PHP. I know that Redux is a Javascript pattern and works with listeners and notifications, but I just ignored this as it doesn't make a lot of sense in PHP. 

The point is that having a central repository of truth in the app you can reliably derive the html from it (using a templating framework like twig you don't need to keep track of the different objects in the controller, you just pass the current state to the view) and you can also store and reproduce use cases very easily: an use case is a list of actions, that can be stored and reproduced with almost no extra code.

 I think I should also add the pattern to the main Readme and add an uml diagram, but please tell me if you would be interested in merging this and if you miss something else to explain the pattern.

Thanks
 