### PR TITLE
Correct variable names in specification test

### DIFF
--- a/Behavioral/Specification/Tests/SpecificationTest.php
+++ b/Behavioral/Specification/Tests/SpecificationTest.php
@@ -27,20 +27,20 @@ class SpecificationTest extends \PHPUnit_Framework_TestCase
         $spec1 = new PriceSpecification(50, 100);
         $spec2 = new PriceSpecification(80, 200);
 
-        $orSpec = new AndSpecification($spec1, $spec2);
+        $andSpec = new AndSpecification($spec1, $spec2);
 
-        $this->assertFalse($orSpec->isSatisfiedBy(new Item(150)));
-        $this->assertFalse($orSpec->isSatisfiedBy(new Item(1)));
-        $this->assertFalse($orSpec->isSatisfiedBy(new Item(51)));
-        $this->assertTrue($orSpec->isSatisfiedBy(new Item(100)));
+        $this->assertFalse($andSpec->isSatisfiedBy(new Item(150)));
+        $this->assertFalse($andSpec->isSatisfiedBy(new Item(1)));
+        $this->assertFalse($andSpec->isSatisfiedBy(new Item(51)));
+        $this->assertTrue($andSpec->isSatisfiedBy(new Item(100)));
     }
 
     public function testCanNot()
     {
         $spec1 = new PriceSpecification(50, 100);
-        $orSpec = new NotSpecification($spec1);
+        $notSpec = new NotSpecification($spec1);
 
-        $this->assertTrue($orSpec->isSatisfiedBy(new Item(150)));
-        $this->assertFalse($orSpec->isSatisfiedBy(new Item(50)));
+        $this->assertTrue($notSpec->isSatisfiedBy(new Item(150)));
+        $this->assertFalse($notSpec->isSatisfiedBy(new Item(50)));
     }
 }


### PR DESCRIPTION
Correct variable names to reflect the specifications being tested.