### PR TITLE
Feature/class instead of namespace

### DIFF
--- a/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
+++ b/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
@@ -3,7 +3,9 @@
 namespace DesignPatterns\Creational\AbstractFactory\Tests;
 
 use DesignPatterns\Creational\AbstractFactory\HtmlFactory;
+use DesignPatterns\Creational\AbstractFactory\HtmlText;
 use DesignPatterns\Creational\AbstractFactory\JsonFactory;
+use DesignPatterns\Creational\AbstractFactory\JsonText;
 
 class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +14,7 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new HtmlFactory();
         $text = $factory->createText('foobar');
 
-        $this->assertInstanceOf('DesignPatterns\Creational\AbstractFactory\HtmlText', $text);
+        $this->assertInstanceOf(HtmlText::class, $text);
     }
 
     public function testCanCreateJsonText()
@@ -20,6 +22,6 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new JsonFactory();
         $text = $factory->createText('foobar');
 
-        $this->assertInstanceOf('DesignPatterns\Creational\AbstractFactory\JsonText', $text);
+        $this->assertInstanceOf(JsonText::class, $text);
     }
 }

--- a/Creational/Builder/Tests/DirectorTest.php
+++ b/Creational/Builder/Tests/DirectorTest.php
@@ -2,6 +2,8 @@
 
 namespace DesignPatterns\Creational\Builder\Tests;
 
+use DesignPatterns\Creational\Builder\Parts\Car;
+use DesignPatterns\Creational\Builder\Parts\Truck;
 use DesignPatterns\Creational\Builder\TruckBuilder;
 use DesignPatterns\Creational\Builder\CarBuilder;
 use DesignPatterns\Creational\Builder\Director;
@@ -13,7 +15,7 @@ class DirectorTest extends \PHPUnit_Framework_TestCase
         $truckBuilder = new TruckBuilder();
         $newVehicle = (new Director())->build($truckBuilder);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\Builder\Parts\Truck', $newVehicle);
+        $this->assertInstanceOf(Truck::class, $newVehicle);
     }
 
     public function testCanBuildCar()
@@ -21,6 +23,6 @@ class DirectorTest extends \PHPUnit_Framework_TestCase
         $carBuilder = new CarBuilder();
         $newVehicle = (new Director())->build($carBuilder);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\Builder\Parts\Car', $newVehicle);
+        $this->assertInstanceOf(Car::class, $newVehicle);
     }
 }

--- a/Creational/FactoryMethod/Tests/FactoryMethodTest.php
+++ b/Creational/FactoryMethod/Tests/FactoryMethodTest.php
@@ -2,6 +2,9 @@
 
 namespace DesignPatterns\Creational\FactoryMethod\Tests;
 
+use DesignPatterns\Creational\FactoryMethod\Bicycle;
+use DesignPatterns\Creational\FactoryMethod\CarFerrari;
+use DesignPatterns\Creational\FactoryMethod\CarMercedes;
 use DesignPatterns\Creational\FactoryMethod\FactoryMethod;
 use DesignPatterns\Creational\FactoryMethod\GermanFactory;
 use DesignPatterns\Creational\FactoryMethod\ItalianFactory;
@@ -13,7 +16,7 @@ class FactoryMethodTest extends \PHPUnit_Framework_TestCase
         $factory = new GermanFactory();
         $result = $factory->create(FactoryMethod::CHEAP);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\FactoryMethod\Bicycle', $result);
+        $this->assertInstanceOf(Bicycle::class, $result);
     }
 
     public function testCanCreateFastVehicleInGermany()
@@ -21,7 +24,7 @@ class FactoryMethodTest extends \PHPUnit_Framework_TestCase
         $factory = new GermanFactory();
         $result = $factory->create(FactoryMethod::FAST);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\FactoryMethod\CarMercedes', $result);
+        $this->assertInstanceOf(CarMercedes::class, $result);
     }
 
     public function testCanCreateCheapVehicleInItaly()
@@ -29,7 +32,7 @@ class FactoryMethodTest extends \PHPUnit_Framework_TestCase
         $factory = new ItalianFactory();
         $result = $factory->create(FactoryMethod::CHEAP);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\FactoryMethod\Bicycle', $result);
+        $this->assertInstanceOf(Bicycle::class, $result);
     }
 
     public function testCanCreateFastVehicleInItaly()
@@ -37,7 +40,7 @@ class FactoryMethodTest extends \PHPUnit_Framework_TestCase
         $factory = new ItalianFactory();
         $result = $factory->create(FactoryMethod::FAST);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\FactoryMethod\CarFerrari', $result);
+        $this->assertInstanceOf(CarFerrari::class, $result);
     }
 
     /**

--- a/Creational/Multiton/Tests/MultitonTest.php
+++ b/Creational/Multiton/Tests/MultitonTest.php
@@ -11,7 +11,7 @@ class MultitonTest extends \PHPUnit_Framework_TestCase
         $firstCall = Multiton::getInstance(Multiton::INSTANCE_1);
         $secondCall = Multiton::getInstance(Multiton::INSTANCE_1);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\Multiton\Multiton', $firstCall);
+        $this->assertInstanceOf(Multiton::class, $firstCall);
         $this->assertSame($firstCall, $secondCall);
     }
 
@@ -20,8 +20,8 @@ class MultitonTest extends \PHPUnit_Framework_TestCase
         $firstCall = Multiton::getInstance(Multiton::INSTANCE_1);
         $secondCall = Multiton::getInstance(Multiton::INSTANCE_2);
 
-        $this->assertInstanceOf('DesignPatterns\Creational\Multiton\Multiton', $firstCall);
-        $this->assertInstanceOf('DesignPatterns\Creational\Multiton\Multiton', $secondCall);
+        $this->assertInstanceOf(Multiton::class, $firstCall);
+        $this->assertInstanceOf(Multiton::class, $secondCall);
         $this->assertNotSame($firstCall, $secondCall);
     }
 }

--- a/Creational/Prototype/Tests/PrototypeTest.php
+++ b/Creational/Prototype/Tests/PrototypeTest.php
@@ -15,13 +15,13 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
         for ($i = 0; $i < 10; $i++) {
             $book = clone $fooPrototype;
             $book->setTitle('Foo Book No ' . $i);
-            $this->assertInstanceOf('DesignPatterns\Creational\Prototype\FooBookPrototype', $book);
+            $this->assertInstanceOf(FooBookPrototype::class, $book);
         }
 
         for ($i = 0; $i < 5; $i++) {
             $book = clone $barPrototype;
             $book->setTitle('Bar Book No ' . $i);
-            $this->assertInstanceOf('DesignPatterns\Creational\Prototype\BarBookPrototype', $book);
+            $this->assertInstanceOf(BarBookPrototype::class, $book);
         }
     }
 }

--- a/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
+++ b/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace DesignPatterns\Creational\SimpleFactory\Tests;
 
+use DesignPatterns\Creational\SimpleFactory\Bicycle;
 use DesignPatterns\Creational\SimpleFactory\SimpleFactory;
 
 class SimpleFactoryTest extends \PHPUnit_Framework_TestCase
@@ -9,6 +10,6 @@ class SimpleFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCanCreateBicycle()
     {
         $bicycle = (new SimpleFactory())->createBicycle();
-        $this->assertInstanceOf('DesignPatterns\Creational\SimpleFactory\Bicycle', $bicycle);
+        $this->assertInstanceOf(Bicycle::class, $bicycle);
     }
 }

--- a/Creational/Singleton/Tests/SingletonTest.php
+++ b/Creational/Singleton/Tests/SingletonTest.php
@@ -11,7 +11,7 @@ class SingletonTest extends \PHPUnit_Framework_TestCase
         $firstCall = Singleton::getInstance();
         $secondCall = Singleton::getInstance();
 
-        $this->assertInstanceOf('DesignPatterns\Creational\Singleton\Singleton', $firstCall);
+        $this->assertInstanceOf(Singleton::class, $firstCall);
         $this->assertSame($firstCall, $secondCall);
     }
 }

--- a/More/ServiceLocator/Tests/ServiceLocatorTest.php
+++ b/More/ServiceLocator/Tests/ServiceLocatorTest.php
@@ -31,6 +31,6 @@ class ServiceLocatorTest extends TestCase
         $this->serviceLocator->addClass(LogService::class, []);
         $logger = $this->serviceLocator->get(LogService::class);
 
-        $this->assertInstanceOf('DesignPatterns\More\ServiceLocator\LogService', $logger);
+        $this->assertInstanceOf(LogService::class, $logger);
     }
 }

--- a/Structural/DataMapper/Tests/DataMapperTest.php
+++ b/Structural/DataMapper/Tests/DataMapperTest.php
@@ -3,6 +3,7 @@
 namespace DesignPatterns\Structural\DataMapper\Tests;
 
 use DesignPatterns\Structural\DataMapper\StorageAdapter;
+use DesignPatterns\Structural\DataMapper\User;
 use DesignPatterns\Structural\DataMapper\UserMapper;
 
 class DataMapperTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +15,7 @@ class DataMapperTest extends \PHPUnit_Framework_TestCase
 
         $user = $mapper->findById(1);
 
-        $this->assertInstanceOf('DesignPatterns\Structural\DataMapper\User', $user);
+        $this->assertInstanceOf(User::class, $user);
     }
 
     /**

--- a/Structural/Proxy/Tests/ProxyTest.php
+++ b/Structural/Proxy/Tests/ProxyTest.php
@@ -19,6 +19,6 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
         $recordProxy = new RecordProxy([]);
         $recordProxy->username = 'baz';
 
-        $this->assertInstanceOf('DesignPatterns\Structural\Proxy\Record', $recordProxy);
+        $this->assertInstanceOf(RecordProxy::class, $recordProxy);
     }
 }

--- a/Structural/Proxy/Tests/ProxyTest.php
+++ b/Structural/Proxy/Tests/ProxyTest.php
@@ -2,7 +2,6 @@
 
 namespace DesignPatterns\Structural\Proxy\Tests;
 
-use DesignPatterns\Structural\Decorator;
 use DesignPatterns\Structural\Proxy\RecordProxy;
 
 class ProxyTest extends \PHPUnit_Framework_TestCase

--- a/Structural/Registry/Tests/RegistryTest.php
+++ b/Structural/Registry/Tests/RegistryTest.php
@@ -3,19 +3,20 @@
 namespace DesignPatterns\Structural\Registry\Tests;
 
 use DesignPatterns\Structural\Registry\Registry;
+use stdClass;
 
 class RegistryTest extends \PHPUnit_Framework_TestCase
 {
     public function testSetAndGetLogger()
     {
         $key = Registry::LOGGER;
-        $logger = new \stdClass();
+        $logger = new stdClass();
 
         Registry::set($key, $logger);
         $storedLogger = Registry::get($key);
 
         $this->assertSame($logger, $storedLogger);
-        $this->assertInstanceOf('stdClass', $storedLogger);
+        $this->assertInstanceOf(stdClass::class, $storedLogger);
     }
 
     /**
@@ -23,7 +24,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenTryingToSetInvalidKey()
     {
-        Registry::set('foobar', new \stdClass());
+        Registry::set('foobar', new stdClass());
     }
 
     /**


### PR DESCRIPTION
Hello!
Here is my contribution: use class constant, introduced in PHP 5.5, to assert that an object is an instance of a concrete class. In my point of view, with this mod test classes are more readable.

Thanks!
