### PR TITLE
Feature/upgrade to phpunit 6

### DIFF
--- a/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
+++ b/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Behavioral\ChainOfResponsibilities\Tests;
 use DesignPatterns\Behavioral\ChainOfResponsibilities\Handler;
 use DesignPatterns\Behavioral\ChainOfResponsibilities\Responsible\HttpInMemoryCacheHandler;
 use DesignPatterns\Behavioral\ChainOfResponsibilities\Responsible\SlowDatabaseHandler;
+use PHPUnit\Framework\TestCase;
 
-class ChainTest extends \PHPUnit_Framework_TestCase
+class ChainTest extends TestCase
 {
     /**
      * @var Handler

--- a/Behavioral/Command/Tests/CommandTest.php
+++ b/Behavioral/Command/Tests/CommandTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Behavioral\Command\Tests;
 use DesignPatterns\Behavioral\Command\HelloCommand;
 use DesignPatterns\Behavioral\Command\Invoker;
 use DesignPatterns\Behavioral\Command\Receiver;
+use PHPUnit\Framework\TestCase;
 
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
     public function testInvocation()
     {

--- a/Behavioral/Command/Tests/UndoableCommandTest.php
+++ b/Behavioral/Command/Tests/UndoableCommandTest.php
@@ -6,8 +6,9 @@ use DesignPatterns\Behavioral\Command\AddMessageDateCommand;
 use DesignPatterns\Behavioral\Command\HelloCommand;
 use DesignPatterns\Behavioral\Command\Invoker;
 use DesignPatterns\Behavioral\Command\Receiver;
+use PHPUnit\Framework\TestCase;
 
-class UndoableCommandTest extends \PHPUnit_Framework_TestCase
+class UndoableCommandTest extends TestCase
 {
     public function testInvocation()
     {

--- a/Behavioral/Iterator/Tests/IteratorTest.php
+++ b/Behavioral/Iterator/Tests/IteratorTest.php
@@ -6,8 +6,9 @@ use DesignPatterns\Behavioral\Iterator\Book;
 use DesignPatterns\Behavioral\Iterator\BookList;
 use DesignPatterns\Behavioral\Iterator\BookListIterator;
 use DesignPatterns\Behavioral\Iterator\BookListReverseIterator;
+use PHPUnit\Framework\TestCase;
 
-class IteratorTest extends \PHPUnit_Framework_TestCase
+class IteratorTest extends TestCase
 {
     public function testCanIterateOverBookList()
     {

--- a/Behavioral/Mediator/Tests/MediatorTest.php
+++ b/Behavioral/Mediator/Tests/MediatorTest.php
@@ -6,8 +6,9 @@ use DesignPatterns\Behavioral\Mediator\Mediator;
 use DesignPatterns\Behavioral\Mediator\Subsystem\Client;
 use DesignPatterns\Behavioral\Mediator\Subsystem\Database;
 use DesignPatterns\Behavioral\Mediator\Subsystem\Server;
+use PHPUnit\Framework\TestCase;
 
-class MediatorTest extends \PHPUnit_Framework_TestCase
+class MediatorTest extends TestCase
 {
     public function testOutputHelloWorld()
     {

--- a/Behavioral/Memento/Tests/MementoTest.php
+++ b/Behavioral/Memento/Tests/MementoTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Behavioral\Memento\Tests;
 
 use DesignPatterns\Behavioral\Memento\State;
 use DesignPatterns\Behavioral\Memento\Ticket;
+use PHPUnit\Framework\TestCase;
 
-class MementoTest extends \PHPUnit_Framework_TestCase
+class MementoTest extends TestCase
 {
     public function testOpenTicketAssignAndSetBackToOpen()
     {

--- a/Behavioral/NullObject/Tests/LoggerTest.php
+++ b/Behavioral/NullObject/Tests/LoggerTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Behavioral\NullObject\Tests;
 use DesignPatterns\Behavioral\NullObject\NullLogger;
 use DesignPatterns\Behavioral\NullObject\PrintLogger;
 use DesignPatterns\Behavioral\NullObject\Service;
+use PHPUnit\Framework\TestCase;
 
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends TestCase
 {
     public function testNullObject()
     {

--- a/Behavioral/Observer/Tests/ObserverTest.php
+++ b/Behavioral/Observer/Tests/ObserverTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Behavioral\Observer\Tests;
 
 use DesignPatterns\Behavioral\Observer\User;
 use DesignPatterns\Behavioral\Observer\UserObserver;
+use PHPUnit\Framework\TestCase;
 
-class ObserverTest extends \PHPUnit_Framework_TestCase
+class ObserverTest extends TestCase
 {
     public function testChangeInUserLeadsToUserObserverBeingNotified()
     {

--- a/Behavioral/Specification/Tests/SpecificationTest.php
+++ b/Behavioral/Specification/Tests/SpecificationTest.php
@@ -7,8 +7,9 @@ use DesignPatterns\Behavioral\Specification\NotSpecification;
 use DesignPatterns\Behavioral\Specification\OrSpecification;
 use DesignPatterns\Behavioral\Specification\AndSpecification;
 use DesignPatterns\Behavioral\Specification\PriceSpecification;
+use PHPUnit\Framework\TestCase;
 
-class SpecificationTest extends \PHPUnit_Framework_TestCase
+class SpecificationTest extends TestCase
 {
     public function testCanOr()
     {

--- a/Behavioral/State/Tests/StateTest.php
+++ b/Behavioral/State/Tests/StateTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Behavioral\State\Tests;
 
 use DesignPatterns\Behavioral\State\OrderRepository;
+use PHPUnit\Framework\TestCase;
 
-class StateTest extends \PHPUnit_Framework_TestCase
+class StateTest extends TestCase
 {
     public function testCanShipCreatedOrder()
     {

--- a/Behavioral/Strategy/Tests/StrategyTest.php
+++ b/Behavioral/Strategy/Tests/StrategyTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Behavioral\Strategy\Tests;
 use DesignPatterns\Behavioral\Strategy\DateComparator;
 use DesignPatterns\Behavioral\Strategy\IdComparator;
 use DesignPatterns\Behavioral\Strategy\ObjectCollection;
+use PHPUnit\Framework\TestCase;
 
-class StrategyTest extends \PHPUnit_Framework_TestCase
+class StrategyTest extends TestCase
 {
     public function provideIntegers()
     {

--- a/Behavioral/TemplateMethod/Tests/JourneyTest.php
+++ b/Behavioral/TemplateMethod/Tests/JourneyTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Behavioral\TemplateMethod\Tests;
 
 use DesignPatterns\Behavioral\TemplateMethod;
+use PHPUnit\Framework\TestCase;
 
-class JourneyTest extends \PHPUnit_Framework_TestCase
+class JourneyTest extends TestCase
 {
     public function testCanGetOnVacationOnTheBeach()
     {

--- a/Behavioral/Visitor/Tests/VisitorTest.php
+++ b/Behavioral/Visitor/Tests/VisitorTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Tests\Visitor\Tests;
 
 use DesignPatterns\Behavioral\Visitor;
+use PHPUnit\Framework\TestCase;
 
-class VisitorTest extends \PHPUnit_Framework_TestCase
+class VisitorTest extends TestCase
 {
     /**
      * @var Visitor\RoleVisitor

--- a/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
+++ b/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Creational\AbstractFactory\Tests;
 
 use DesignPatterns\Creational\AbstractFactory\HtmlFactory;
 use DesignPatterns\Creational\AbstractFactory\JsonFactory;
+use PHPUnit\Framework\TestCase;
 
-class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
+class AbstractFactoryTest extends TestCase
 {
     public function testCanCreateHtmlText()
     {

--- a/Creational/Builder/Tests/DirectorTest.php
+++ b/Creational/Builder/Tests/DirectorTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Creational\Builder\Tests;
 use DesignPatterns\Creational\Builder\TruckBuilder;
 use DesignPatterns\Creational\Builder\CarBuilder;
 use DesignPatterns\Creational\Builder\Director;
+use PHPUnit\Framework\TestCase;
 
-class DirectorTest extends \PHPUnit_Framework_TestCase
+class DirectorTest extends TestCase
 {
     public function testCanBuildTruck()
     {

--- a/Creational/FactoryMethod/Tests/FactoryMethodTest.php
+++ b/Creational/FactoryMethod/Tests/FactoryMethodTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Creational\FactoryMethod\Tests;
 use DesignPatterns\Creational\FactoryMethod\FactoryMethod;
 use DesignPatterns\Creational\FactoryMethod\GermanFactory;
 use DesignPatterns\Creational\FactoryMethod\ItalianFactory;
+use PHPUnit\Framework\TestCase;
 
-class FactoryMethodTest extends \PHPUnit_Framework_TestCase
+class FactoryMethodTest extends TestCase
 {
     public function testCanCreateCheapVehicleInGermany()
     {

--- a/Creational/Multiton/Tests/MultitonTest.php
+++ b/Creational/Multiton/Tests/MultitonTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Creational\Multition\Tests;
 
 use DesignPatterns\Creational\Multiton\Multiton;
+use PHPUnit\Framework\TestCase;
 
-class MultitonTest extends \PHPUnit_Framework_TestCase
+class MultitonTest extends TestCase
 {
     public function testUniqueness()
     {

--- a/Creational/Pool/Tests/PoolTest.php
+++ b/Creational/Pool/Tests/PoolTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Creational\Pool\Tests;
 
 use DesignPatterns\Creational\Pool\WorkerPool;
+use PHPUnit\Framework\TestCase;
 
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends TestCase
 {
     public function testCanGetNewInstancesWithGet()
     {

--- a/Creational/Prototype/Tests/PrototypeTest.php
+++ b/Creational/Prototype/Tests/PrototypeTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Creational\Prototype\Tests;
 
 use DesignPatterns\Creational\Prototype\BarBookPrototype;
 use DesignPatterns\Creational\Prototype\FooBookPrototype;
+use PHPUnit\Framework\TestCase;
 
-class PrototypeTest extends \PHPUnit_Framework_TestCase
+class PrototypeTest extends TestCase
 {
     public function testCanGetFooBook()
     {

--- a/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
+++ b/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Creational\SimpleFactory\Tests;
 
 use DesignPatterns\Creational\SimpleFactory\SimpleFactory;
+use PHPUnit\Framework\TestCase;
 
-class SimpleFactoryTest extends \PHPUnit_Framework_TestCase
+class SimpleFactoryTest extends TestCase
 {
     public function testCanCreateBicycle()
     {

--- a/Creational/Singleton/Tests/SingletonTest.php
+++ b/Creational/Singleton/Tests/SingletonTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Creational\Singleton\Tests;
 
 use DesignPatterns\Creational\Singleton\Singleton;
+use PHPUnit\Framework\TestCase;
 
-class SingletonTest extends \PHPUnit_Framework_TestCase
+class SingletonTest extends TestCase
 {
     public function testUniqueness()
     {

--- a/Creational/StaticFactory/Tests/StaticFactoryTest.php
+++ b/Creational/StaticFactory/Tests/StaticFactoryTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Creational\StaticFactory\Tests;
 
 use DesignPatterns\Creational\StaticFactory\StaticFactory;
+use PHPUnit\Framework\TestCase;
 
-class StaticFactoryTest extends \PHPUnit_Framework_TestCase
+class StaticFactoryTest extends TestCase
 {
     public function testCanCreateNumberFormatter()
     {

--- a/More/Delegation/Tests/DelegationTest.php
+++ b/More/Delegation/Tests/DelegationTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\More\Delegation\Tests;
 
 use DesignPatterns\More\Delegation;
+use PHPUnit\Framework\TestCase;
 
-class DelegationTest extends \PHPUnit_Framework_TestCase
+class DelegationTest extends TestCase
 {
     public function testHowTeamLeadWriteCode()
     {

--- a/More/EAV/Tests/EAVTest.php
+++ b/More/EAV/Tests/EAVTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\More\EAV\Tests;
 use DesignPatterns\More\EAV\Attribute;
 use DesignPatterns\More\EAV\Entity;
 use DesignPatterns\More\EAV\Value;
+use PHPUnit\Framework\TestCase;
 
-class EAVTest extends \PHPUnit_Framework_TestCase
+class EAVTest extends TestCase
 {
     public function testCanAddAttributeToEntity()
     {

--- a/More/Repository/Tests/RepositoryTest.php
+++ b/More/Repository/Tests/RepositoryTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\More\Repository\Tests;
 use DesignPatterns\More\Repository\MemoryStorage;
 use DesignPatterns\More\Repository\Post;
 use DesignPatterns\More\Repository\PostRepository;
+use PHPUnit\Framework\TestCase;
 
-class Repository extends \PHPUnit_Framework_TestCase
+class Repository extends TestCase
 {
     public function testCanPersistAndFindPost()
     {

--- a/More/ServiceLocator/Tests/ServiceLocatorTest.php
+++ b/More/ServiceLocator/Tests/ServiceLocatorTest.php
@@ -4,7 +4,7 @@ namespace DesignPatterns\More\ServiceLocator\Tests;
 
 use DesignPatterns\More\ServiceLocator\LogService;
 use DesignPatterns\More\ServiceLocator\ServiceLocator;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ServiceLocatorTest extends TestCase
 {

--- a/Structural/Adapter/Tests/AdapterTest.php
+++ b/Structural/Adapter/Tests/AdapterTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Structural\Adapter\Tests;
 use DesignPatterns\Structural\Adapter\Book;
 use DesignPatterns\Structural\Adapter\EBookAdapter;
 use DesignPatterns\Structural\Adapter\Kindle;
+use PHPUnit\Framework\TestCase;
 
-class AdapterTest extends \PHPUnit_Framework_TestCase
+class AdapterTest extends TestCase
 {
     public function testCanTurnPageOnBook()
     {

--- a/Structural/Bridge/Tests/BridgeTest.php
+++ b/Structural/Bridge/Tests/BridgeTest.php
@@ -5,8 +5,9 @@ namespace DesignPatterns\Structural\Bridge\Tests;
 use DesignPatterns\Structural\Bridge\HelloWorldService;
 use DesignPatterns\Structural\Bridge\HtmlFormatter;
 use DesignPatterns\Structural\Bridge\PlainTextFormatter;
+use PHPUnit\Framework\TestCase;
 
-class BridgeTest extends \PHPUnit_Framework_TestCase
+class BridgeTest extends TestCase
 {
     public function testCanPrintUsingThePlainTextPrinter()
     {

--- a/Structural/Composite/Tests/CompositeTest.php
+++ b/Structural/Composite/Tests/CompositeTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Structural\Composite\Tests;
 
 use DesignPatterns\Structural\Composite;
+use PHPUnit\Framework\TestCase;
 
-class CompositeTest extends \PHPUnit_Framework_TestCase
+class CompositeTest extends TestCase
 {
     public function testRender()
     {

--- a/Structural/DataMapper/Tests/DataMapperTest.php
+++ b/Structural/DataMapper/Tests/DataMapperTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Structural\DataMapper\Tests;
 
 use DesignPatterns\Structural\DataMapper\StorageAdapter;
 use DesignPatterns\Structural\DataMapper\UserMapper;
+use PHPUnit\Framework\TestCase;
 
-class DataMapperTest extends \PHPUnit_Framework_TestCase
+class DataMapperTest extends TestCase
 {
     public function testCanMapUserFromStorage()
     {

--- a/Structural/Decorator/Tests/DecoratorTest.php
+++ b/Structural/Decorator/Tests/DecoratorTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Structural\Decorator\Tests;
 
 use DesignPatterns\Structural\Decorator;
+use PHPUnit\Framework\TestCase;
 
-class DecoratorTest extends \PHPUnit_Framework_TestCase
+class DecoratorTest extends TestCase
 {
     /**
      * @var Decorator\Webservice

--- a/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
+++ b/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Structural\DependencyInjection\Tests;
 
 use DesignPatterns\Structural\DependencyInjection\DatabaseConfiguration;
 use DesignPatterns\Structural\DependencyInjection\DatabaseConnection;
+use PHPUnit\Framework\TestCase;
 
-class DependencyInjectionTest extends \PHPUnit_Framework_TestCase
+class DependencyInjectionTest extends TestCase
 {
     public function testDependencyInjection()
     {

--- a/Structural/Facade/Tests/FacadeTest.php
+++ b/Structural/Facade/Tests/FacadeTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Structural\Facade\Tests;
 
 use DesignPatterns\Structural\Facade\Facade;
 use DesignPatterns\Structural\Facade\OsInterface;
+use PHPUnit\Framework\TestCase;
 
-class FacadeTest extends \PHPUnit_Framework_TestCase
+class FacadeTest extends TestCase
 {
     public function testComputerOn()
     {

--- a/Structural/FluentInterface/Tests/FluentInterfaceTest.php
+++ b/Structural/FluentInterface/Tests/FluentInterfaceTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Structural\FluentInterface\Tests;
 
 use DesignPatterns\Structural\FluentInterface\Sql;
+use PHPUnit\Framework\TestCase;
 
-class FluentInterfaceTest extends \PHPUnit_Framework_TestCase
+class FluentInterfaceTest extends TestCase
 {
     public function testBuildSQL()
     {

--- a/Structural/Flyweight/Tests/FlyweightTest.php
+++ b/Structural/Flyweight/Tests/FlyweightTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Structural\Flyweight\Tests;
 
 use DesignPatterns\Structural\Flyweight\FlyweightFactory;
+use PHPUnit\Framework\TestCase;
 
-class FlyweightTest extends \PHPUnit_Framework_TestCase
+class FlyweightTest extends TestCase
 {
     private $characters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
         'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];

--- a/Structural/Proxy/Tests/ProxyTest.php
+++ b/Structural/Proxy/Tests/ProxyTest.php
@@ -4,8 +4,9 @@ namespace DesignPatterns\Structural\Proxy\Tests;
 
 use DesignPatterns\Structural\Decorator;
 use DesignPatterns\Structural\Proxy\RecordProxy;
+use PHPUnit\Framework\TestCase;
 
-class ProxyTest extends \PHPUnit_Framework_TestCase
+class ProxyTest extends TestCase
 {
     public function testWillSetDirtyFlagInProxy()
     {

--- a/Structural/Registry/Tests/RegistryTest.php
+++ b/Structural/Registry/Tests/RegistryTest.php
@@ -3,8 +3,9 @@
 namespace DesignPatterns\Structural\Registry\Tests;
 
 use DesignPatterns\Structural\Registry\Registry;
+use PHPUnit\Framework\TestCase;
 
-class RegistryTest extends \PHPUnit_Framework_TestCase
+class RegistryTest extends TestCase
 {
     public function testSetAndGetLogger()
     {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.5.4",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "1.5.*"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "61109e150871360cd44739b2a6bea702",
-    "content-hash": "53848b7fc8e374b8e407799bb47d6917",
+    "content-hash": "967b2d81af5c0ae65ab57db374efe747",
     "packages": [
         {
             "name": "psr/http-message",
@@ -55,7 +54,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [
@@ -111,20 +110,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.4",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
                 "shasum": ""
             },
             "require": {
@@ -153,7 +152,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-09-16 13:37:59"
+            "time": "2017-01-26T22:05:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -207,7 +206,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -252,20 +251,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -299,31 +298,32 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -361,44 +361,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
+                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "~1.0|~2.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^2.0",
+                "sebastian/version": "^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -424,20 +424,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-26 14:39:29"
+            "time": "2017-03-06T14:22:16+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -471,7 +471,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -512,29 +512,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -556,20 +561,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -605,20 +610,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.5.5",
+            "version": "6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a57126dc681b08289fef6ac96a48e30656f84350"
+                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a57126dc681b08289fef6ac96a48e30656f84350",
-                "reference": "a57126dc681b08289fef6ac96a48e30656f84350",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
+                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
                 "shasum": ""
             },
             "require": {
@@ -627,34 +632,33 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "myclabs/deep-copy": "^1.3",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^5.0",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^4.0",
+                "sebastian/comparator": "^1.2.4 || ^2.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/environment": "^2.0",
+                "sebastian/exporter": "^2.0 || ^3.0",
+                "sebastian/global-state": "^1.1 || ^2.0",
+                "sebastian/object-enumerator": "^2.0 || ^3.0",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
-                "ext-tidy": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -662,7 +666,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.5.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -688,33 +692,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-09-21 14:40:13"
+            "time": "2017-03-02T15:24:03+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.7",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a"
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
-                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "sebastian/exporter": "^3.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -722,7 +726,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -747,27 +751,27 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-09-06 16:07:45"
+            "time": "2017-03-03T06:30:20+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -792,34 +796,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^7.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/exporter": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -856,7 +860,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-03-03T06:26:08+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -908,32 +912,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -958,34 +962,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b82d077cb3459e393abcf4867ae8f7230dcb51f6",
+                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1025,7 +1029,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2017-03-03T06:25:06+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1076,33 +1080,33 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "de6e32f7192dfea2e4bedc892434f4830b5c5794"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/de6e32f7192dfea2e4bedc892434f4830b5c5794",
+                "reference": "de6e32f7192dfea2e4bedc892434f4830b5c5794",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1122,32 +1126,32 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2017-03-03T06:21:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1175,7 +1179,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1217,20 +1221,20 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
@@ -1260,7 +1264,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1335,73 +1339,24 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v3.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-02 02:12:52"
+            "time": "2014-12-04T22:32:15+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1410,7 +1365,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1434,7 +1389,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Hello!
Since code is for PHP >= 7.0, here is an upgrade to PHPUnit 6
Output:
```
./vendor/bin/phpunit --verbose
PHPUnit 6.0.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.3 with Xdebug 2.4.0RC4
Configuration: /Users/Hyunkel/code/DesignPatternsPHP/phpunit.xml.dist

..........R...................................................... 65 / 68 ( 95%)
...                                                               68 / 68 (100%)

Time: 380 ms, Memory: 8.00MB

There was 1 risky test:

1) DesignPatterns\Behavioral\NullObject\Tests\LoggerTest::testNullObject
This test did not perform any assertions

OK, but incomplete, skipped, or risky tests!
Tests: 68, Assertions: 208, Risky: 1.
```

Thanks!