### PR TITLE
Remove VehicleInterface.php reference

### DIFF
--- a/Creational/SimpleFactory/README.rst
+++ b/Creational/SimpleFactory/README.rst
@@ -28,12 +28,6 @@ SimpleFactory.php
    :language: php
    :linenos:
 
-VehicleInterface.php
-
-.. literalinclude:: VehicleInterface.php
-   :language: php
-   :linenos:
-
 Bicycle.php
 
 .. literalinclude:: Bicycle.php


### PR DESCRIPTION
The file does not appear in the folder and thus does not render on the page as expected.

<img width="757" alt="screen shot 2017-03-29 at 12 05 05 pm" src="https://cloud.githubusercontent.com/assets/2218833/24464559/3cb1ec3c-1478-11e7-91c4-35b6fa4af7a8.png">
