### PR TITLE
Change PaperBookInterface to BookInterface

### DIFF
--- a/Structural/Adapter/README.rst
+++ b/Structural/Adapter/README.rst
@@ -30,7 +30,7 @@ You can also find these code on `GitHub`_
 
 BookInterface.php
 
-.. literalinclude:: PaperBookInterface.php
+.. literalinclude:: BookInterface.php
    :language: php
    :linenos:
 


### PR DESCRIPTION
It looks like the file name was updated in a few places, but not properly changed in the include line.

<img width="745" alt="screen shot 2017-03-29 at 12 12 35 pm" src="https://cloud.githubusercontent.com/assets/2218833/24464789/0c7066d8-1479-11e7-8b4e-e9619b36b509.png">
