### PR TITLE
Specification pattern - performance optimization

### DIFF
--- a/Behavioral/Specification/AndSpecification.php
+++ b/Behavioral/Specification/AndSpecification.php
@@ -17,14 +17,17 @@ class AndSpecification implements SpecificationInterface
         $this->specifications = $specifications;
     }
 
+    /**
+     * if at least one specification is false, return false, else return true.
+     */
     public function isSatisfiedBy(Item $item): bool
     {
-        $satisfied = [];
-
         foreach ($this->specifications as $specification) {
-            $satisfied[] = $specification->isSatisfiedBy($item);
+            if (!$specification->isSatisfiedBy($item)) {
+                return false;
+            }
         }
 
-        return !in_array(false, $satisfied);
+        return true;
     }
 }

--- a/Behavioral/Specification/OrSpecification.php
+++ b/Behavioral/Specification/OrSpecification.php
@@ -17,14 +17,16 @@ class OrSpecification implements SpecificationInterface
         $this->specifications = $specifications;
     }
 
+    /**
+     * if at least one specification is true, return true, else return false
+     */
     public function isSatisfiedBy(Item $item): bool
     {
-        $satisfied = [];
-
         foreach ($this->specifications as $specification) {
-            $satisfied[] = $specification->isSatisfiedBy($item);
+            if ($specification->isSatisfiedBy($item)) {
+                return true;
+            }
         }
-
-        return in_array(true, $satisfied);
+        return false;
     }
 }


### PR DESCRIPTION
Specification pattern - performance optimization

there's no need to loop on all the specifications if one of them don't match the requirements, added a break inside the loop to stop the moment we know the result is false