### PR TITLE
The "protected" keyword should be used in order to subclasses to use …

### DIFF
--- a/Creational/AbstractFactory/Text.php
+++ b/Creational/AbstractFactory/Text.php
@@ -7,7 +7,7 @@ abstract class Text
     /**
      * @var string
      */
-    private $text;
+    protected $text;
 
     public function __construct(string $text)
     {

--- a/Creational/SimpleFactory/README.rst
+++ b/Creational/SimpleFactory/README.rst
@@ -7,7 +7,7 @@ Purpose
 SimpleFactory is a simple factory pattern.
 
 It differs from the static factory because it is not static.
-Therefore, you can have multiple factories, differently parametrized, you can subclass it and you can mock it.
+Therefore, you can have multiple factories, differently parameterized, you can subclass it and you can mock it.
 It always should be preferred over a static factory!
 
 UML Diagram

--- a/Structural/DependencyInjection/README.rst
+++ b/Structural/DependencyInjection/README.rst
@@ -10,7 +10,7 @@ testable, maintainable and extendable code.
 Usage
 -----
 
-DatabaseConfiguration gets injected and ``DatabaseConnection`` will get all that it
+``DatabaseConfiguration`` gets injected and ``DatabaseConnection`` will get all that it
 needs from ``$config``. Without DI, the configuration would be created
 directly in ``DatabaseConnection``, which is not very good for testing and
 extending it.

--- a/locale/ca/LC_MESSAGES/Creational/SimpleFactory/README.po
+++ b/locale/ca/LC_MESSAGES/Creational/SimpleFactory/README.po
@@ -1,4 +1,4 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: DesignPatternsPHP 1.0\n"
@@ -31,7 +31,7 @@ msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:12
 msgid ""
-"Therefore, you can have multiple factories, differently parametrized, you "
+"Therefore, you can have multiple factories, differently parameterized, you "
 "can subclass it and you can mock-up it."
 msgstr ""
 

--- a/locale/template/LC_MESSAGES/Creational/SimpleFactory/README.pot
+++ b/locale/template/LC_MESSAGES/Creational/SimpleFactory/README.pot
@@ -23,7 +23,7 @@ msgstr ""
 #: ../../Creational/SimpleFactory/README.rst:9
 msgid ""
 "It differs from the static factory because it is not static. "
-"Therefore, you can have multiple factories, differently parametrized, you can subclass it and you can mock it."
+"Therefore, you can have multiple factories, differently parameterized, you can subclass it and you can mock it."
 msgstr ""
 
 #: ../../Creational/SimpleFactory/README.rst:11

--- a/locale/template/LC_MESSAGES/Structural/DependencyInjection/README.pot
+++ b/locale/template/LC_MESSAGES/Structural/DependencyInjection/README.pot
@@ -28,7 +28,7 @@ msgstr ""
 
 #: ../../Structural/DependencyInjection/README.rst:13
 msgid ""
-"DatabaseConfiguration gets injected and ``DatabaseConnection`` will get all that it "
+"``DatabaseConfiguration`` gets injected and ``DatabaseConnection`` will get all that it "
 "needs from ``$config``. Without DI, the configuration would be created "
 "directly in ``DatabaseConnection``, which is not very good for testing and "
 "extending it."


### PR DESCRIPTION
…that property. Otherwise, saying "$this->text = $text" is not making sense for extender objects.