### PR TITLE
Add composer image to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,10 @@ services:
     volumes:
       - .:/opt/php
     command: ["/opt/php/docker/test_runner.sh"]
+  composer:
+    image: composer:latest
+    working_dir: /app
+    volumes:
+       - .:/app
+    command:
+      - install


### PR DESCRIPTION
There's a service for php but we need to install composer in the php container or worse, install projects' dependencies through composer installed locally.

It adds a new service for composer and permit to run composer within a container with just a command: `docker-compose run composer install`.