### PR TITLE
Fixed mistype in Repository readme

### DIFF
--- a/More/Repository/README.rst
+++ b/More/Repository/README.rst
@@ -57,7 +57,7 @@ PostRepository.php
 
 Persistence.php
 
-.. literalinclude:: InMemoryPersistence.php
+.. literalinclude:: Persistence.php
    :language: php
    :linenos:
 


### PR DESCRIPTION
There was `InMemoryPersistence.php` dublicate instead `Persistence.php`