### PR TITLE
Change link for local docker startup in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just run:
 $ docker-compose up --build
 ```
 
-Go to [http://localhost:8080/README.html](http://localhost:8080/README.html) to read the generated documentation.
+Go to [http://localhost:8080](http://localhost:8080) to read the generated documentation.
 
 ## Patterns
 


### PR DESCRIPTION
When the docker build was changed to a multi-stage build a step got added that renames the README.html to index.html.

Currently, following the link in the readme.md you receive a 404.

Relevant commit: https://github.com/domnikl/DesignPatternsPHP/commit/be66dcc037f8b2293134efe3cc3f2e87a25b8f80