### PR TITLE
Dockerfile > Change Composer 2 to 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1 AS composer
 WORKDIR /app
 ADD . /app
 RUN composer global require hirak/prestissimo


### PR DESCRIPTION
The current Composer image is using Composer 2 and it's not compatible with the project dependencies, it because of the compose plugin installed, so I changed it to Compose 1 lastest version to make it work again.